### PR TITLE
Add baseline TSP invariant model scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+torch
+numpy
+scikit-learn
+matplotlib
+tqdm

--- a/src/evaluate_model.py
+++ b/src/evaluate_model.py
@@ -1,0 +1,76 @@
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+from sklearn.metrics import mean_squared_error
+from torch.utils.data import DataLoader, Dataset
+
+from transformations import RandomRotate, RandomTranslate, RandomPermute
+from utils import compute_pairwise_distance, load_scaler
+
+
+class TSPDataset(Dataset):
+    def __init__(self, path, max_points=50):
+        self.data = json.load(open(path))
+        self.max_points = max_points
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        entry = self.data[idx]
+        points = np.asarray(entry["points"], dtype=np.float32)
+        dist = compute_pairwise_distance(points, self.max_points)
+        score = (
+            entry.get("score")
+            or entry.get("opt_dist")
+            or entry.get("opt_dist_true")
+        )
+        return dist.flatten(), np.array([score], dtype=np.float32)
+
+
+def evaluate(model, dataloader, device):
+    model.eval()
+    preds, targets = [], []
+    with torch.no_grad():
+        for x, y in dataloader:
+            x = x.to(device)
+            out = model(x).cpu().numpy()
+            preds.append(out)
+            targets.append(y.numpy())
+    preds = np.concatenate(preds, axis=0)
+    targets = np.concatenate(targets, axis=0)
+    return mean_squared_error(targets, preds)
+
+
+def main(args):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    dataset = TSPDataset(args.dataset)
+    dataloader = DataLoader(dataset, batch_size=args.batch_size)
+    model = torch.nn.Sequential(
+        torch.nn.Linear(50 * 50, 512),
+        torch.nn.ReLU(),
+        torch.nn.Linear(512, 128),
+        torch.nn.ReLU(),
+        torch.nn.Linear(128, 1),
+    ).to(device)
+    model.load_state_dict(torch.load(args.model, map_location=device))
+    scaler = load_scaler(args.scaler)
+    mse = evaluate(model, dataloader, device)
+    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    with open(Path(args.output_dir) / "metrics.json", "w") as f:
+        json.dump({"mse": mse}, f, indent=2)
+    print(f"MSE: {mse:.4f}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--scaler", type=Path, required=True)
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument("--output_dir", type=Path, default=Path("outputs/eval"))
+    parser.add_argument("--batch_size", type=int, default=256)
+    args = parser.parse_args()
+    main(args)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,12 @@
+import torch
+from torch import nn
+
+
+def invariant_mlp(input_dim):
+    return nn.Sequential(
+        nn.Linear(input_dim, 512),
+        nn.ReLU(),
+        nn.Linear(512, 128),
+        nn.ReLU(),
+        nn.Linear(128, 1),
+    )

--- a/src/train_invariance.py
+++ b/src/train_invariance.py
@@ -1,0 +1,106 @@
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+from sklearn.preprocessing import StandardScaler
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+from tqdm import tqdm
+
+from transformations import RandomRotate, RandomTranslate, RandomPermute
+from utils import compute_pairwise_distance, save_json
+
+
+class TSPDataset(Dataset):
+    def __init__(self, path, max_points=50, augment=False):
+        self.data = json.load(open(path))
+        self.max_points = max_points
+        self.augment = augment
+        self.transforms = [RandomRotate(), RandomTranslate(), RandomPermute()]
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        entry = self.data[idx]
+        points = np.asarray(entry["points"], dtype=np.float32)
+        if self.augment:
+            for t in self.transforms:
+                points = t(points)
+        dist = compute_pairwise_distance(points, self.max_points)
+        score = (
+            entry.get("score")
+            or entry.get("opt_dist")
+            or entry.get("opt_dist_true")
+        )
+        return dist.flatten(), np.array([score], dtype=np.float32)
+
+
+def build_model(input_dim):
+    return nn.Sequential(
+        nn.Linear(input_dim, 512),
+        nn.ReLU(),
+        nn.Linear(512, 128),
+        nn.ReLU(),
+        nn.Linear(128, 1),
+    )
+
+
+def train(model, dataloader, criterion, optimizer, device):
+    model.train()
+    running_loss = 0.0
+    for x, y in tqdm(dataloader, leave=False):
+        x, y = x.to(device), y.to(device)
+        optimizer.zero_grad()
+        out = model(x)
+        loss = criterion(out, y)
+        loss.backward()
+        optimizer.step()
+        running_loss += loss.item() * x.size(0)
+    return running_loss / len(dataloader.dataset)
+
+
+def main(args):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    dataset = TSPDataset(args.dataset, augment=True)
+    scaler = StandardScaler()
+    all_scores = [(
+        d.get("score")
+        or d.get("opt_dist")
+        or d.get("opt_dist_true")
+    ) for d in dataset.data]
+    scaler.fit(np.array(all_scores).reshape(-1, 1))
+    labels = scaler.transform(np.array(all_scores).reshape(-1, 1)).astype(np.float32)
+
+    for idx, label in enumerate(labels):
+        dataset.data[idx]["scaled_score"] = label[0]
+
+    dataloader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+    model = build_model(50 * 50).to(device)
+    criterion = nn.MSELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.learning_rate)
+
+    history = []
+    for epoch in range(1, args.epochs + 1):
+        loss = train(model, dataloader, criterion, optimizer, device)
+        history.append({"epoch": epoch, "loss": loss})
+        print(f"Epoch {epoch}/{args.epochs} - loss: {loss:.4f}")
+
+    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), Path(args.output_dir) / "tsp_invariant_model.pt")
+    with open(Path(args.output_dir) / "scaler.pkl", "wb") as f:
+        torch.save(scaler, f)
+    save_json({"history": history}, Path(args.output_dir) / "metrics.json")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument("--batch_size", type=int, default=256)
+    parser.add_argument("--epochs", type=int, default=50)
+    parser.add_argument("--learning_rate", type=float, default=1e-3)
+    parser.add_argument("--output_dir", type=Path, default=Path("outputs/train"))
+    args = parser.parse_args()
+    main(args)

--- a/src/transformations.py
+++ b/src/transformations.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+
+class RandomRotate:
+    def __init__(self, max_angle=2 * np.pi):
+        self.max_angle = max_angle
+
+    def __call__(self, points):
+        theta = np.random.uniform(0, self.max_angle)
+        c, s = np.cos(theta), np.sin(theta)
+        rot = np.array([[c, -s], [s, c]], dtype=np.float32)
+        return points @ rot
+
+
+class RandomTranslate:
+    def __init__(self, range_val=1.0):
+        self.range_val = range_val
+
+    def __call__(self, points):
+        shift = np.random.uniform(-self.range_val, self.range_val, size=(1, 2)).astype(np.float32)
+        return points + shift
+
+
+class RandomPermute:
+    def __call__(self, points):
+        perm = np.random.permutation(len(points))
+        return points[perm]

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+def compute_pairwise_distance(points, max_points=50):
+    n = len(points)
+    diff = points[:, None, :] - points[None, :, :]
+    dist = np.linalg.norm(diff, axis=-1)
+    if n < max_points:
+        padded = np.zeros((max_points, max_points), dtype=np.float32)
+        padded[:n, :n] = dist
+        return padded
+    else:
+        return dist[:max_points, :max_points]
+
+
+def save_json(obj, path):
+    with open(path, "w") as f:
+        json.dump(obj, f, indent=2)
+
+
+def load_scaler(path):
+    with open(path, "rb") as f:
+        return torch.load(f)


### PR DESCRIPTION
## Summary
- add simple training script `train_invariance.py`
- add evaluation script `evaluate_model.py`
- include basic transformations and utilities
- provide requirements file
- remove temporary `__pycache__` content

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68400c8b33d8832f856d4f7c48566991